### PR TITLE
Fix pour les imports path du module Database

### DIFF
--- a/serveur-web/api-v2/database/database.py
+++ b/serveur-web/api-v2/database/database.py
@@ -13,7 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from sqlite_connection import SqliteConnection
+# Fix de compatibilité des imports pour "Migration"
+try:
+	from database.sqlite_connection import SqliteConnection
+except:
+	from sqlite_connection import SqliteConnection
 
 class Database(object):
 	"""

--- a/serveur-web/api-v2/database/migration.py
+++ b/serveur-web/api-v2/database/migration.py
@@ -12,8 +12,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
-from database import Database
+try:
+	from database import Database
+except:
+	from database.database import Database
 
 # Recouvre l'instance de la DB
 db = Database.get_instance()

--- a/serveur-web/api-v2/database/sqlite_connection.py
+++ b/serveur-web/api-v2/database/sqlite_connection.py
@@ -14,7 +14,12 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-from connection import Connection
+# Fix de compatibilité des imports pour "Migration"
+try:
+	from database.connection import Connection
+except:
+	from connection import Connection
+
 import sqlite3
 
 


### PR DESCRIPTION
Rend possible l'utilisation des modules de database par l'app Flask
ainsi que par le script de migration.

Si quelqu'un trouve une manière propre de faire, n'hésiter pas à faire
une PR.